### PR TITLE
Fix variable reference for totalBytes in download process

### DIFF
--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -30,7 +30,7 @@ if (-not (Test-Path -Path $binDir)) {
 try {
     # Download the executable directly
 
-    $totalBytes = $response.Headers["Content-Length"]
+    $totalBytes = $webClient.ResponseHeaders["Content-Length"]
     $downloadedBytes = 0
     $bufferSize = 8192
 


### PR DESCRIPTION
Fix wrong variable reference in PowerShell install script